### PR TITLE
fix(plugins/plugin-logui): improve log rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -222,6 +222,7 @@
         "@kui-shell/plugin-core-support": "^6.0.12",
         "@kui-shell/plugin-editor": "^6.0.12",
         "@kui-shell/plugin-kubeui": "*",
+        "ansi_up": "4.0.4",
         "debug": "4.1.1",
         "js-yaml": "3.13.1"
       }
@@ -889,6 +890,11 @@
       "requires": {
         "entities": "^1.1.2"
       }
+    },
+    "ansi_up": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/ansi_up/-/ansi_up-4.0.4.tgz",
+      "integrity": "sha512-vRxC8q6QY918MbehO869biJW4tiunJdjOhi5fpY6NLOliBQlZhOkKgABJKJqH+JZfb/WfjvjN1chLWI6tODerw=="
     },
     "any-observable": {
       "version": "0.3.0",

--- a/plugins/plugin-kubeui-client/index.js
+++ b/plugins/plugin-kubeui-client/index.js
@@ -14,4 +14,5 @@
  * limitations under the License.
  */
 
+import './web/css/static/colors.css'
 require('@kui-shell/plugin-client-default')

--- a/plugins/plugin-kubeui-client/web/css/static/colors.css
+++ b/plugins/plugin-kubeui-client/web/css/static/colors.css
@@ -1,0 +1,40 @@
+.kubeui--logs {
+  line-height: 1.25em;
+}
+.kubeui--logs .ansi-cyan-fg {
+  font-size: 0.875em;
+}
+.ansi-bright-black-fg {
+  color: var(--color-text-02);
+}
+.ansi-black-fg {
+  color: var(--color-text-01);
+}
+.ansi-bright-blue-fg,
+.ansi-blue-fg {
+  color: var(--color-blue);
+}
+.ansi-bright-red-fg,
+.ansi-red-fg {
+  color: var(--color-red);
+}
+.ansi-bright-green-fg,
+.ansi-green-fg {
+  color: var(--color-green);
+}
+.ansi-bright-yellow-fg,
+.ansi-yellow-fg {
+  color: var(--color-yellow-text);
+}
+.ansi-bright-magenta-fg,
+.ansi-magenta-fg {
+  color: var(--color-magenta);
+}
+.ansi-bright-cyan-fg,
+.ansi-cyan-fg {
+  color: var(--color-cyan);
+}
+.ansi-bright-white-fg,
+.ansi-white-fg {
+  color: var(--color-white);
+}

--- a/plugins/plugin-kubeui/src/controller/kubectl/exec.ts
+++ b/plugins/plugin-kubeui/src/controller/kubectl/exec.ts
@@ -28,7 +28,7 @@ import {
 
 import RawResponse from './response'
 import commandPrefix from '../command-prefix'
-import { KubeOptions, getNamespaceForArgv, getContextForArgv, fileOf } from './options'
+import { KubeOptions, getNamespaceForArgv, getContextForArgv, fileOf, isHelpRequest } from './options'
 
 import { renderHelp } from '../../lib/util/help'
 import { FinalState } from '../../lib/model/states'
@@ -98,7 +98,7 @@ const isKubectl = (args: Arguments<KubeOptions>) =>
     args.argvNoOptions[0] === commandPrefix &&
     /^k(ubectl)?$/.test(args.argvNoOptions[1]))
 
-const isUsage = (args: Arguments<KubeOptions>) => args.parsedOptions.help || args.parsedOptions.h || isKubectl(args)
+const isUsage = (args: Arguments<KubeOptions>) => isHelpRequest(args) || isKubectl(args)
 
 function doHelp<O extends KubeOptions>(args: Arguments<O>, response: RawResponse): void {
   const verb = args.argvNoOptions.length >= 2 ? args.argvNoOptions[1] : ''

--- a/plugins/plugin-kubeui/src/controller/kubectl/options.ts
+++ b/plugins/plugin-kubeui/src/controller/kubectl/options.ts
@@ -50,6 +50,10 @@ function isTableFormat(format: OutputFormat): format is TableFormat {
   return !format || format === 'wide' || /^custom-columns=/.test(format) || /^custom-columns-file=/.test(format)
 }
 
+export function isHelpRequest(args: Arguments<KubeOptions>) {
+  return args.parsedOptions.help || args.parsedOptions.h
+}
+
 export function isTableRequest(args: Arguments<KubeOptions>) {
   return isTableFormat(formatOf(args))
 }
@@ -151,6 +155,9 @@ export interface KubeOptions extends ParsedOptions {
 
   f?: string
   filename?: string
+
+  h?: boolean
+  help?: boolean
 }
 
 export function isForAllNamespaces(args: Arguments<KubeOptions>) {

--- a/plugins/plugin-kubeui/src/index.ts
+++ b/plugins/plugin-kubeui/src/index.ts
@@ -54,6 +54,7 @@ export {
   hasLabel,
   getLabel,
   getLabelForArgv,
+  isHelpRequest,
   getNamespace,
   getNamespaceForArgv,
   isForAllNamespaces

--- a/plugins/plugin-logui/package.json
+++ b/plugins/plugin-logui/package.json
@@ -31,6 +31,7 @@
     "@kui-shell/plugin-core-support": "^6.0.12",
     "@kui-shell/plugin-editor": "^6.0.12",
     "@kui-shell/plugin-kubeui": "*",
+    "ansi_up": "4.0.4",
     "debug": "4.1.1",
     "js-yaml": "3.13.1"
   },

--- a/plugins/plugin-logui/src/test/logs/logs.ts
+++ b/plugins/plugin-logui/src/test/logs/logs.ts
@@ -68,9 +68,8 @@ describe(`kubectl logs getty ${process.env.MOCHA_RUN_TARGET || ''}`, function(th
       if (hasLogs) {
         await Promise.resolve(res)
           .then(ReplExpect.okWithCustom({ passthrough: true }))
-          .then(N => this.app.client.elements(Selectors.LIST_RESULTS_BY_NAME_N(N)))
-          .then(rows => rows.value.length)
-          .then(nRows => assert.ok(nRows > 0))
+          .then(N => this.app.client.getText(Selectors.OUTPUT_N_STREAMING(N)))
+          .then(txt => assert.ok(txt.length > 0))
       } else {
         await Promise.resolve(res).then(ReplExpect.justOK)
       }


### PR DESCRIPTION
stop using tables to present logs, and instead present mostly raw logs, filtered only through regexp for formatting

Fixes #291