### PR TITLE
fix: The drilldown command for oc tables is hardcoded to `kubectl`

### DIFF
--- a/plugins/plugin-kubeui/src/controller/kubectl/get-namespaces.ts
+++ b/plugins/plugin-kubeui/src/controller/kubectl/get-namespaces.ts
@@ -28,13 +28,13 @@ import { summarizeNamespaceOnSwitch } from '@kui-shell/client/config.d/kubectl.j
  * Special table for namespaces
  *
  */
-async function doGetNamespaceTable(args: Arguments<KubeOptions>) {
+async function doGetNamespaceTable(command: string, args: Arguments<KubeOptions>) {
   const [
     baseTable,
     {
       metadata: { namespace: currentNamespace }
     }
-  ] = await Promise.all([doGetAsTable(args, await rawGet(args)), getCurrentContext(args.tab)])
+  ] = await Promise.all([doGetAsTable(command, args, await rawGet(args)), getCurrentContext(args.tab)])
 
   // user asked for a table, and *did not* ask for a watchable table?
   // then decorate the table as a row-selectable table
@@ -102,11 +102,11 @@ async function doGetNamespaceTable(args: Arguments<KubeOptions>) {
  * table, or the default get impl.
  *
  */
-function doGetNamespace(args: Arguments<KubeOptions>) {
+const doGetNamespace = (command: string) => (args: Arguments<KubeOptions>) => {
   if (isTableRequest(args) && !isWatchRequest(args) && args.execOptions.type !== ExecType.Nested) {
-    return doGetNamespaceTable(args)
+    return doGetNamespaceTable(command, args)
   } else {
-    return doGet('kubectl')(args)
+    return doGet(command)(args)
   }
 }
 
@@ -189,12 +189,12 @@ async function doGetCurrentNamespace({ tab }: Arguments<KubeOptions>) {
 }
 
 export default (commandTree: Registrar) => {
-  commandTree.listen(`/${commandPrefix}/kubectl/get/namespaces`, doGetNamespace, flags)
-  commandTree.listen(`/${commandPrefix}/k/get/namespaces`, doGetNamespace, flags)
-  commandTree.listen(`/${commandPrefix}/kubectl/get/namespace`, doGetNamespace, flags)
-  commandTree.listen(`/${commandPrefix}/k/get/namespace`, doGetNamespace, flags)
-  commandTree.listen(`/${commandPrefix}/kubectl/get/ns`, doGetNamespace, flags)
-  commandTree.listen(`/${commandPrefix}/k/get/ns`, doGetNamespace, flags)
+  commandTree.listen(`/${commandPrefix}/kubectl/get/namespaces`, doGetNamespace('kubectl'), flags)
+  commandTree.listen(`/${commandPrefix}/k/get/namespaces`, doGetNamespace('k'), flags)
+  commandTree.listen(`/${commandPrefix}/kubectl/get/namespace`, doGetNamespace('kubectl'), flags)
+  commandTree.listen(`/${commandPrefix}/k/get/namespace`, doGetNamespace('k'), flags)
+  commandTree.listen(`/${commandPrefix}/kubectl/get/ns`, doGetNamespace('kubectl'), flags)
+  commandTree.listen(`/${commandPrefix}/k/get/ns`, doGetNamespace('k'), flags)
 
   commandTree.listen(`/${commandPrefix}/namespace/current`, doGetCurrentNamespace, flags)
   commandTree.listen(`/${commandPrefix}/namespace/summarize`, doSummarizeNamespace, flags)

--- a/plugins/plugin-kubeui/src/controller/kubectl/get.ts
+++ b/plugins/plugin-kubeui/src/controller/kubectl/get.ts
@@ -44,12 +44,16 @@ function prepareArgsForGet(args: Arguments<KubeOptions>) {
  * `kubectl get` as a table response
  *
  */
-export function doGetAsTable(args: Arguments<KubeOptions>, response: RawResponse, verb = 'get'): KubeTableResponse {
+export function doGetAsTable(
+  command: string,
+  args: Arguments<KubeOptions>,
+  response: RawResponse,
+  verb = 'get'
+): KubeTableResponse {
   const {
     content: { stderr, stdout }
   } = response
 
-  const command = 'kubectl'
   const entityType = args.argvNoOptions[args.argvNoOptions.indexOf(verb) + 1]
 
   return stringToTable(stdout, stderr, args, command, verb, entityType)
@@ -181,7 +185,7 @@ export const doGet = (command: string) =>
       return doGetAsEntity(args, response)
     } else if (isTableRequest(args)) {
       // case 2: get-as-table
-      return doGetAsTable(args, response)
+      return doGetAsTable(command, args, response)
     } else {
       // case 3: get-as-custom
       return doGetCustom(args, response)

--- a/plugins/plugin-kubeui/src/controller/kubectl/top.ts
+++ b/plugins/plugin-kubeui/src/controller/kubectl/top.ts
@@ -29,20 +29,21 @@ const verb = 'top'
  * This is the main handler for `kubectl top`.
  *
  */
-async function doTop(args: Arguments<KubeOptions>): Promise<KResponse> {
-  if (isUsage(args)) {
-    return doHelp('kubectl', args)
-  } else {
-    // first, we do the raw exec of the given command
-    const response = await exec(args)
+const doTop = (command: string) =>
+  async function _doTop(args: Arguments<KubeOptions>): Promise<KResponse> {
+    if (isUsage(args)) {
+      return doHelp(command, args)
+    } else {
+      // first, we do the raw exec of the given command
+      const response = await exec(args)
 
-    return doGetAsTable(args, response, verb)
+      return doGetAsTable(command, args, response, verb)
+    }
   }
-}
 
 export default (commandTree: Registrar) => {
-  commandTree.listen(`/${commandPrefix}/kubectl/${verb}/node`, doTop, flags)
-  commandTree.listen(`/${commandPrefix}/k/${verb}/node`, doTop, flags)
-  commandTree.listen(`/${commandPrefix}/kubectl/${verb}/pod`, doTop, flags)
-  commandTree.listen(`/${commandPrefix}/k/${verb}/pod`, doTop, flags)
+  commandTree.listen(`/${commandPrefix}/kubectl/${verb}/node`, doTop('kubectl'), flags)
+  commandTree.listen(`/${commandPrefix}/k/${verb}/node`, doTop('k'), flags)
+  commandTree.listen(`/${commandPrefix}/kubectl/${verb}/pod`, doTop('kubectl'), flags)
+  commandTree.listen(`/${commandPrefix}/k/${verb}/pod`, doTop('k'), flags)
 }


### PR DESCRIPTION
Fixes #408