### PR TITLE
fix: some underlying kubectl get commands are not disambiguating resources with the same kind

### DIFF
--- a/plugins/plugin-kubeui/src/controller/kubectl/status.ts
+++ b/plugins/plugin-kubeui/src/controller/kubectl/status.ts
@@ -339,7 +339,12 @@ class StatusWatcher implements Abortable, Watcher {
         onclick: `kubectl get ${fqnOfRef(ref)} -o yaml`,
         onclickSilence: true,
         attributes: this.nsAttr(namespace, anyNonDefaultNamespaces).concat([
-          { key: 'KIND', value: kind + (group.length > 0 ? `.${group}.${version}` : ''), outerCSS: '', css: '' },
+          {
+            key: 'KIND',
+            value: kind + (group.length > 0 ? `.${group}${version ? `.${version}` : ''}` : ''),
+            outerCSS: '',
+            css: ''
+          },
           { key: 'STATUS', tag: 'badge', value: strings('Pending'), outerCSS: '', css: TrafficLight.Yellow }
           // { key: 'MESSAGE', value: '', outerCSS: 'hide-with-sidecar' }
         ])

--- a/plugins/plugin-kubeui/src/lib/view/modes/button.ts
+++ b/plugins/plugin-kubeui/src/lib/view/modes/button.ts
@@ -16,6 +16,7 @@
 
 import { Tab } from '@kui-shell/core'
 import { KubeResource } from '../../model/resource'
+import { fqnOf } from '../../../controller/kubectl/fqn'
 
 /** makeButton is passed a subset of SidecarMode */
 interface BaseInfo {
@@ -25,12 +26,7 @@ interface BaseInfo {
   balloon?: string
 }
 
-export const renderButton = (mode: string) => (tab: Tab, resource: KubeResource) => {
-  const { kind, metadata } = resource
-  const namespace = metadata.namespace
-
-  return `kubectl ${mode} ${kind} ${metadata.name} ${namespace ? '-n ' + namespace : ''}`
-}
+export const renderButton = (mode: string) => (tab: Tab, resource: KubeResource) => `kubectl ${mode} ${fqnOf(resource)}`
 
 const makeButton = (overrides: BaseInfo) => ({
   mode: overrides.mode,

--- a/plugins/plugin-kubeui/src/lib/view/modes/involved-object.ts
+++ b/plugins/plugin-kubeui/src/lib/view/modes/involved-object.ts
@@ -16,6 +16,7 @@
 
 import { i18n, encodeComponent, Tab, ModeRegistration } from '@kui-shell/core'
 
+import { fqn } from '../../../controller/kubectl/fqn'
 import { hasInvolvedObject, KubeResourceWithInvolvedObject } from '../../model/resource'
 
 const strings = i18n('plugin-kubeui')
@@ -24,9 +25,12 @@ const strings = i18n('plugin-kubeui')
  * Extract the events
  *
  */
-function command(tab: Tab, { involvedObject: { kind, name, namespace } }: KubeResourceWithInvolvedObject) {
-  return `kubectl get ${encodeComponent(kind)} ${encodeComponent(name)} -n ${encodeComponent(
-    namespace || 'default'
+function command(tab: Tab, { involvedObject: { apiVersion, kind, name, namespace } }: KubeResourceWithInvolvedObject) {
+  return `kubectl get ${fqn(
+    apiVersion,
+    encodeComponent(kind),
+    encodeComponent(name),
+    encodeComponent(namespace || 'default')
   )} -o yaml`
 }
 

--- a/plugins/plugin-kubeui/src/lib/view/modes/show-crd-managed-resources.ts
+++ b/plugins/plugin-kubeui/src/lib/view/modes/show-crd-managed-resources.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import { i18n, Tab, ModeRegistration } from '@kui-shell/core'
+import { i18n, Tab, ModeRegistration, encodeComponent } from '@kui-shell/core'
 
 import { CustomResourceDefinition, isCustomResourceDefinition } from '../../model/resource'
+import { fqn } from '../../../controller/kubectl/fqn'
 
 const strings = i18n('plugin-kubeui')
 
@@ -25,7 +26,12 @@ const strings = i18n('plugin-kubeui')
  *
  */
 export function command(tab: Tab, crd: CustomResourceDefinition) {
-  return `kubectl get ${tab.REPL.encodeComponent(crd.metadata.name)}`
+  return `kubectl get ${fqn(
+    crd.apiVersion,
+    encodeComponent(crd.kind),
+    encodeComponent(crd.metadata.name),
+    encodeComponent(crd.metadata.namespace || 'default')
+  )}`
 }
 
 /**

--- a/plugins/plugin-kubeui/src/lib/view/modes/summary.ts
+++ b/plugins/plugin-kubeui/src/lib/view/modes/summary.ts
@@ -17,6 +17,7 @@
 import { i18n, Tab, Table, ModeRegistration } from '@kui-shell/core'
 
 import toMap from './table-to-map'
+import { fqnOf } from '../../../controller/kubectl/fqn'
 import { KubeResource, isSummarizableKubeResource, isKubeResourceWithItsOwnSummary } from '../../model/resource'
 
 const strings = i18n('plugin-kubeui')
@@ -31,7 +32,7 @@ async function renderSummary(tab: Tab, resource: KubeResource) {
   }
 
   // a command that will fetch a single-row table
-  const cmd = `kubectl get ${resource.kind} ${resource.metadata.name} -n ${resource.metadata.namespace} -o wide`
+  const cmd = `kubectl get ${fqnOf(resource)} -o wide`
 
   // in parallel, fetch the table model and the safeDump function from js-yaml
   const [map, { safeDump }] = await Promise.all([tab.REPL.qexec<Table>(cmd).then(toMap), import('js-yaml')])

--- a/plugins/plugin-kubeui/src/test/k8s1/apply-crd.ts
+++ b/plugins/plugin-kubeui/src/test/k8s1/apply-crd.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2018-19 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Common, CLI, ReplExpect, SidecarExpect, Selectors, Util } from '@kui-shell/test'
+import {
+  waitForRed,
+  waitForGreen,
+  defaultModeForGet,
+  createNS,
+  allocateNS,
+  deleteNS
+} from '@kui-shell/plugin-kubeui/tests/lib/k8s/utils'
+
+import { dirname } from 'path'
+const ROOT = dirname(require.resolve('@kui-shell/plugin-kubeui/tests/package.json'))
+
+describe(`kubectl apply crd ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
+  before(Common.before(this))
+  after(Common.after(this))
+
+  const ns: string = createNS()
+  const inNamespace = `-n ${ns}`
+  const crdName = 'crontabs.stable.example.com'
+  const kind = 'CustomResourceDefinition'
+  const apiGroup = 'apiextensions.k8s.io'
+
+  allocateNS(this, ns)
+
+  it(`should create custom resource definition from file via "kubectl apply -f"`, async () => {
+    try {
+      console.error('kubectl apply crd 1')
+      const selector = await CLI.command(`kubectl apply -f ${ROOT}/data/k8s/crd.yaml ${inNamespace}`, this.app)
+        .then(ReplExpect.okWithCustom({ selector: Selectors.BY_NAME(crdName) }))
+        .catch(Common.oops(this))
+
+      // wait for the badge to become green
+      console.error('kubectl apply crd 2')
+      await waitForGreen(this.app, selector)
+
+      // now click on the table row
+      console.error('kubectl apply crd 3')
+      await this.app.client.click(`${selector} .clickable`)
+      await SidecarExpect.open(this.app)
+        .then(SidecarExpect.mode(defaultModeForGet))
+        .then(SidecarExpect.showing(crdName))
+
+      let idx = 0
+      await this.app.client.waitUntil(async () => {
+        const text = await Util.getValueFromMonaco(this.app)
+        if (++idx > 5) {
+          console.error(`still waiting for yaml in ${this.title}`, text)
+        }
+
+        return Promise.resolve(text).then(
+          Util.expectYAMLSubset(
+            {
+              kind: 'CronTab'
+            },
+            false
+          )
+        )
+      })
+    } catch (err) {
+      return Common.oops(this, true)(err)
+    }
+  })
+
+  it(`should switch to last applied tab of custom resource definitions`, async () => {
+    try {
+      // make sure we have a last applied tab
+      console.error('kubectl apply crd 4')
+      await this.app.client.waitForVisible(Selectors.SIDECAR_MODE_BUTTON('last applied'))
+      await this.app.client.click(Selectors.SIDECAR_MODE_BUTTON('last applied'))
+      await this.app.client.waitForVisible(Selectors.SIDECAR_MODE_BUTTON_SELECTED('last applied'))
+
+      let idx = 0
+      console.error('kubectl apply crd 5')
+      await this.app.client.waitUntil(async () => {
+        const text = await Util.getValueFromMonaco(this.app)
+        if (++idx > 5) {
+          console.error(`still waiting for yaml in ${this.title}`, text)
+        }
+
+        return Promise.resolve(text).then(
+          Util.expectYAMLSubset(
+            {
+              apiVersion: 'apiextensions.k8s.io/v1beta1',
+              kind: 'CustomResourceDefinition',
+              metadata: {
+                name: crdName
+              }
+            },
+            false
+          )
+        )
+      })
+      console.error('kubectl apply crd 6')
+    } catch (err) {
+      return Common.oops(this, true)(err)
+    }
+  })
+
+  it('should open crd in sidecar, then click on Show Resources button', async () => {
+    try {
+      const res = await CLI.command(`kubectl get ${kind}.${apiGroup} -n ${ns} ${crdName} -o yaml`, this.app)
+
+      console.error('kubectl apply crd 7')
+      await Promise.resolve(res)
+        .then(ReplExpect.justOK)
+        .then(SidecarExpect.open)
+        .then(SidecarExpect.showing(crdName))
+        .catch(Common.oops(this, true))
+
+      await this.app.client.waitForVisible(Selectors.SIDECAR_MODE_BUTTON('show-crd-resources'))
+      await this.app.client.click(Selectors.SIDECAR_MODE_BUTTON('show-crd-resources'))
+
+      await Promise.resolve({ app: this.app, count: res.count + 1 }).then(
+        ReplExpect.okWithCustom({ selector: Selectors.BY_NAME(crdName) })
+      )
+    } catch (err) {
+      await Common.oops(this, true)(err)
+    }
+  })
+
+  it(`should delete the custom resource definition from URL via kubectl`, () => {
+    return CLI.command(`kubectl delete -f ${ROOT}/data/k8s/crd.yaml ${inNamespace}`, this.app)
+      .then(ReplExpect.okWithCustom({ selector: Selectors.BY_NAME(crdName) }))
+      .then(selector => waitForRed(this.app, selector))
+      .catch(Common.oops(this, true))
+  })
+
+  deleteNS(this, ns)
+})

--- a/plugins/plugin-kubeui/tests/data/k8s/crd.yaml
+++ b/plugins/plugin-kubeui/tests/data/k8s/crd.yaml
@@ -1,0 +1,51 @@
+# resource from: https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#create-a-customresourcedefinition
+# Deprecated in v1.16 in favor of apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: crontabs.stable.example.com
+spec:
+  group: stable.example.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  scope: Namespaced
+  names:
+    plural: crontabs
+    singular: crontab
+    kind: CronTab
+    shortNames:
+    - ct
+  validation:
+    openAPIV3Schema:
+      type: object
+      properties:
+        spec:
+          type: object
+          properties:
+            cronSpec:
+              type: string
+            image:
+              type: string
+            replicas:
+              type: integer
+        status:
+          type: object
+          properties:
+            replicas:
+              type: integer
+            labelSelector:
+              type: string
+  # subresources describes the subresources for custom resources.
+  subresources:
+    # status enables the status subresource.
+    status: {}
+    # scale enables the scale subresource.
+    scale:
+      # specReplicasPath defines the JSONPath inside of a custom resource that corresponds to Scale.Spec.Replicas.
+      specReplicasPath: .spec.replicas
+      # statusReplicasPath defines the JSONPath inside of a custom resource that corresponds to Scale.Status.Replicas.
+      statusReplicasPath: .status.replicas
+      # labelSelectorPath defines the JSONPath inside of a custom resource that corresponds to Scale.Status.Selector.
+      labelSelectorPath: .status.labelSelector


### PR DESCRIPTION
cherry-pick 92e0cea5e62aa1a1e4e724c9f6bbf2668cf15d1d
[port_411 e643fc0] fix: some underlying kubectl get commands are not disambiguating resources with the same kind